### PR TITLE
Armenr - Provisioner Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 terraform-provisioner-ansible
+.kitchen*
+default.yml
+.DS_STORE
+roles
+installer.sh

--- a/bootstrap_ansible_node.sh
+++ b/bootstrap_ansible_node.sh
@@ -5,14 +5,10 @@
 # ANSIBLE_VERSION if not provided, script will install default ansible version which is 2.3.1
 ANSIBLE_VERSION=$1
 
-_pip_deps(){
-  easy_install pip > /dev/null 2>&1;
-  pip --quiet install -U setuptools > /dev/null 2>&1
-  pip --quiet install -U pip > /dev/null 2>&1
-}
+
 # just to sleep
-sleep 10 ;
-if [[ -f /etc/redhat-release ]];then 
+# sleep 5 ;
+if [[ -f /etc/redhat-release ]]; then 
   yum -y update  > /dev/null 2>&1 && \
   yum -q -y install gcc libffi-devel openssl-devel python-devel  > /dev/null 2>&1;
 elif [[ -f /etc/debian_version ]]; then
@@ -24,13 +20,21 @@ elif [[ -f /etc/SuSE-release ]]; then
   zypper --quiet --non-interactive refresh > /dev/null 2>&1
   zypper --quiet --non-interactive install libffi-devel openssl-devel python-devel python-setuptools > /dev/null 2>&1
 else
-  echo "nothing to do"
+  echo "Nothing to do"
 fi
-# main program starts ;)
-if [ ! -z $ANSIBLE_VERSION ] ; then
-  _pip_deps
-  pip --quiet --log /tmp/pip.log install -U ansible==$ANSIBLE_VERSION
+
+if hash ansible 2>/dev/null; then
+  echo 'Ansible already installed!!' >&2
+  echo 'Proceeding with instance provisioning' >&2
+  exit 0
 else
-  _pip_deps
-  pip --quiet --log /tmp/pip.log install -U 'ansible>=2.3.1,<2.4.0'
+    echo 'Installing pip, python dependencies, and Ansible' >&2
+    echo 'Please stand by' >&2
+    easy_install pip > /dev/null 2>&1
+    echo 'easy_install pip successful' >&2
+    pip -qqq install -U setuptools > /dev/null 2>&1
+    echo 'Installed setuptools' >&2
+    pip -qqq install -U pip > /dev/null 2>&1
+    pip -qqq --log /tmp/pip.log install -U 'ansible>=2.3.2,<2.4.0' > /dev/null 2>&1
+    echo 'Successfully installed Ansible. Provisioning host...' >&2
 fi

--- a/provisioner.go
+++ b/provisioner.go
@@ -85,13 +85,6 @@ func (p *Provisioner) Run(o terraform.UIOutput, comm communicator.Communicator) 
 	// will be uploaded too
 	remotePlaybookPath := filepath.Join("/tmp/ansible", filepath.Base(playbookPath))
 
-	// check if /tmp/ansible exists, and nuke it
-	// this is so that you can deploy changes to roles or playbooks
-	// as you make them
-	// if err := os.Stat("/tmp/ansible/"); os.IsNotExist(err) {
-	// 	os.Remove("/tmp/ansible")
-	// }
-
 	// upload ansible source and playbook to the host
 	if err := comm.UploadDir("/tmp/ansible", playbookDir); err != nil {
 		return err

--- a/provisioner.go
+++ b/provisioner.go
@@ -69,6 +69,13 @@ func (p *Provisioner) Run(o terraform.UIOutput, comm communicator.Communicator) 
 	// will be uploaded too
 	remotePlaybookPath := filepath.Join("/tmp/ansible", filepath.Base(playbookPath))
 
+	// check if /tmp/ansible exists, and nuke it
+	// this is so that you can deploy changes to roles or playbooks
+	// as you make them
+	if err := os.Stat("/tmp/ansible"); os.IsNotExist(err) {
+		os.Remove("/tmp/ansible")
+	}
+
 	// upload ansible source and playbook to the host
 	if err := comm.UploadDir("/tmp/ansible", playbookDir); err != nil {
 		return err

--- a/provisioner.go
+++ b/provisioner.go
@@ -3,25 +3,26 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/hashicorp/terraform/communicator"
 	"github.com/hashicorp/terraform/communicator/remote"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/go-linereader"
-	"io"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 const (
-        installURL = "https://github.com/ravibhure/terraform-provisioner-ansible/raw/master/bootstrap_ansible_node.sh"
+	installURL = "https://github.com/armenr/terraform-provisioner-ansible/raw/master/bootstrap_ansible_node.sh"
 )
 
 type Provisioner struct {
 	useSudo            bool
 	ansibleLocalScript string
-        AnsibleVersion     string            `mapstructure:"ansible_version"` // Ansible version to install
+	AnsibleVersion     string            `mapstructure:"ansible_version"` // Ansible version to install
 	Playbook           string            `mapstructure:"playbook"`
 	Plays              []string          `mapstructure:"plays"`
 	Hosts              []string          `mapstructure:"hosts"`
@@ -39,26 +40,25 @@ func (p *Provisioner) Run(o terraform.UIOutput, comm communicator.Communicator) 
 		return err
 	}
 
-        prefix := ""
+	prefix := ""
 	// Ansible version to be install
-        ansible_version := p.AnsibleVersion
-
+	ansible_version := p.AnsibleVersion
 
 	// commands that are needed to setup a basic environment to run the `ansible-local.py` script
 	// TODO pivot based upon different platforms and allow optional python provision steps
 	// TODO this should be configurable for folks who want to customize this
 
-        // Check before install ansible, system to be ready
-        err = p.runCommand(o, comm, fmt.Sprintf("%sbash -c 'until curl -o /dev/null -sIf %s ; do echo \"Waiting for ansible installURL to be available..\"; ((c++)) && ((c==20)) && break ; sleep 5 ; done'", prefix, installURL))
-        if err != nil {
-                return err
-        }
+	// Check before install ansible, system to be ready
+	err = p.runCommand(o, comm, fmt.Sprintf("%sbash -c 'until curl -o /dev/null -sIf %s ; do echo \"Waiting for ansible installURL to be available..\"; ((c++)) && ((c==20)) && break ; sleep 5 ; done'", prefix, installURL))
+	if err != nil {
+		return err
+	}
 
-        // Then execute the bootstrap_ansible_node.sh scrip to download and install Ansible
-        err = p.runCommand(o, comm, fmt.Sprintf("%scurl -L %s | sudo bash -s -- %s", prefix, installURL, ansible_version))
-        if err != nil {
-                return err
-        }
+	// Then execute the bootstrap_ansible_node.sh script to download and install Ansible
+	err = p.runCommand(o, comm, fmt.Sprintf("%scurl -L -s -S %s | sudo bash -s -- %s", prefix, installURL, ansible_version))
+	if err != nil {
+		return err
+	}
 
 	// ansible projects are structured such that the playbook file is in
 	// the top level of the module path. As such, we parse the playbook
@@ -80,15 +80,19 @@ func (p *Provisioner) Run(o terraform.UIOutput, comm communicator.Communicator) 
 	}
 
 	// build a command to run ansible on the host machine
-	command := fmt.Sprintf("curl -L %s | python - --playbook=%s --hosts=%s --plays=%s --group_vars=%s --extra_vars='%s'",
-		p.ansibleLocalScript,
+	command := fmt.Sprintf("curl -LSs https://raw.githubusercontent.com/armenr/terraform-provisioner-ansible/master/ansible-local.py | python - --playbook=%s --hosts=%s --plays=%s --group_vars=%s --extra_vars='%s'",
 		remotePlaybookPath,
 		strings.Join(p.Hosts, ","),
 		strings.Join(p.Plays, ","),
 		strings.Join(p.GroupVars, ","),
 		string(extraVars))
 
-	o.Output(fmt.Sprintf("running command: %s", command))
+	// o.Output(fmt.Sprintf("running command: %s", command))
+	// if err := p.runCommand(o, comm, command); err != nil {
+	// 	return err
+	// }
+
+	o.Output(fmt.Sprintf("Running ansible plays with: \n %s", command))
 	if err := p.runCommand(o, comm, command); err != nil {
 		return err
 	}
@@ -102,7 +106,6 @@ func (p *Provisioner) Validate() error {
 		return err
 	}
 	p.Playbook = playbookPath
-
 
 	for _, host := range p.Hosts {
 		if host == "" {

--- a/provisioner.go
+++ b/provisioner.go
@@ -72,10 +72,10 @@ func (p *Provisioner) Run(o terraform.UIOutput, comm communicator.Communicator) 
 	// remove stale ansible files from last successful run
 	// this lets you make rapid changes & deploys from the branch
 	// you're working in
-	deleteCommand := fmt.Sprintf("sudo rm -rf /tmp/ansible")
+	deleteCommand := fmt.Sprintf("rm -rf /tmp/ansible")
 
 	if _, err := os.Stat(tmpPath); !os.IsExist(err) {
-		o.Output(fmt.Sprintf("Removing old playbooks plays with: \n %s", deleteCommand))
+		o.Output(fmt.Sprintf("Removing old playbooks plays with: %s", deleteCommand))
 		if err := p.runCommand(o, comm, deleteCommand); err != nil {
 			return err
 		}
@@ -115,7 +115,15 @@ func (p *Provisioner) Run(o terraform.UIOutput, comm communicator.Communicator) 
 	// 	return err
 	// }
 
-	o.Output(fmt.Sprintf("Running ansible plays with: \n %s", command))
+	// 	o.Output(fmt.Sprintf("Running ansible plays with: \n %s", command))
+	// 	if err := p.runCommand(o, comm, command); err != nil {
+	// 		return err
+	// 	}
+
+	// 	return nil
+	// }
+
+	o.Output(fmt.Sprintf("Running the following Ansible plays on target host: \n --> Playbook: %s \n --> Plays: %s", remotePlaybookPath, strings.Join(p.Hosts, ",")))
 	if err := p.runCommand(o, comm, command); err != nil {
 		return err
 	}

--- a/resource_provisioner.go
+++ b/resource_provisioner.go
@@ -41,7 +41,7 @@ func (r *ResourceProvisioner) Apply(
 		return err
 	}
 	provisioner.useSudo = true
-	provisioner.ansibleLocalScript = fmt.Sprintf("https://raw.githubusercontent.com/ravibhure/terraform-provisioner-ansible/%s/ansible-local.py", VERSION)
+	provisioner.ansibleLocalScript = fmt.Sprintf("https://raw.githubusercontent.com/armer/terraform-provisioner-ansible/%s/ansible-local.py", VERSION)
 
 	// ensure that this is a linux machine
 	if s.Ephemeral.ConnInfo["type"] != "ssh" {


### PR DESCRIPTION
This PR addresses the first in a series of iterative modifications I am hoping to make to this provisioner. I am grateful to the original developer, and to the gentleman from whom I forked this repo for their work in creating it, and keeping it alive. I think we can take this further, and make it a much-loved and very useful provisioner - exploiting the strengths of terraform, and capitalizing on a simplified and more unified worflow. More on this magical worflow in the next PR!

My motivations are as follows:

1. The provisioner is noisy and unfriendly. It needed some love. It can be quieter, and it can be friendlier to the user & console.

2. There is a new terraform + ansible workflow/implementation pattern that I've been experimenting with. One that I think could be of great value and convenience. I've been working with this provisioner plugin for a while now, and have come to understand its strengths and weaknesses. I intend to remodel the provisioner to make it less brittle, and no longer dependent on the ansible-local.py script. 

**Reasoning:**
The ansible-local.py script relies on the Ansible 2.3 API which has received breaking-change updates in Ansible 2.4. This plugin's functionality and extensibility cannot be staked on a hand-written python script written around an API which Ansible has admittedly intentionally left undocumented (because the API is for "internal" use).

3. This is fun! :) 

## Changes made:

## boostrap_ansible_node.sh refactored

- Check if Ansible is already installed and skip reinstallation - this was costing precious time and spitting up tons of console output in the old version of the provisioner
- Make the installation quiet/suppress noisy output
- Echo out a message to indicate which script step a potential failure might be taking place at

## resource_provisioner.go modified

- Modified to pull from my forked repository

## provisioner.go refactored

- Added "-s -S" to curl command to make it silent and suppress noisy output, but display output on failure in silent mode
- Remove any potentially present stale ansible roles and playbooks from /tmp/ansible directory before each run
- Clean up and reduce noise for command output on ansible-local provision script command